### PR TITLE
Misplaced ! in ZSAssetManager downloadImage

### DIFF
--- a/ZSAssetManager.m
+++ b/ZSAssetManager.m
@@ -321,7 +321,7 @@ typedef enum {
 
 - (void)downloadImage:(NSURL*)url
 {
-  if (![[ZSReachability reachabilityForInternetConnection] currentReachabilityStatus] == NotReachable) {
+  if ([[ZSReachability reachabilityForInternetConnection] currentReachabilityStatus] == NotReachable) {
     if (CACHE_TEST) DLog(@"connection is offline, refusing to download image");
     return;
   } else {


### PR DESCRIPTION
Misplaced ! prevented downloadImage from starting an image download. Indicated the connection was offline when it wasn't.

Noticed when attempting to get images via imagesForURL and was seeing "connection is offline, refusing to download image" even though my connection was active (wifi or 3G on iPhone, or Wifi via iPhone simulator).
