### PR TITLE
Fix filtering.

### DIFF
--- a/MSZContextWatcher.swift
+++ b/MSZContextWatcher.swift
@@ -57,7 +57,7 @@ class MSZContextWatcher: NSObject {
     delegate = nil
   }
 
-  func addEntityToWastch(desc: NSEntityDescription, predicate: NSPredicate) {
+  func addEntityToWatch(desc: NSEntityDescription, predicate: NSPredicate) {
     guard let name = desc.name else { fatalError("bad desc") }
     let entityPredicate = NSPredicate(format: "entity.name == %@", name)
 
@@ -90,19 +90,20 @@ class MSZContextWatcher: NSObject {
 
     var results = [String:[NSManagedObject]]()
     var totalCount = 0
-    if let insert = info?[NSInsertedObjectsKey] as? [NSManagedObject] {
+    
+    if let insert = info?[NSInsertedObjectsKey] as? Set<NSManagedObject> {
       let filter = insert.filter{ return predicate.evaluateWithObject($0) }
       totalCount += filter.count
       results[NSInsertedObjectsKey] = filter
     }
 
-    if let update = info?[NSUpdatedObjectsKey] as? [NSManagedObject] {
+    if let update = info?[NSUpdatedObjectsKey] as? Set<NSManagedObject> {
       let filter = update.filter{ return predicate.evaluateWithObject($0) }
       totalCount += filter.count
       results[NSUpdatedObjectsKey] = filter
     }
 
-    if let delete = info?[NSDeletedObjectsKey] as? [NSManagedObject] {
+    if let delete = info?[NSDeletedObjectsKey] as? Set<NSManagedObject> {
       let filter = delete.filter{ return predicate.evaluateWithObject($0) }
       totalCount += filter.count
       results[NSDeletedObjectsKey] = filter


### PR DESCRIPTION
On Swift 2.2/XCode 7.3, the predicate filtering was failing.

The objects in the userInfo field are Sets and not Arrays, and so a cast attempt to as? [NSManagedObject] will fail and return nil.

If the info variables are cast to Set<NSManagedObject> then the filtering all works properly.

Bonus: There was a spelling mistake in the addEntityToWatch function name
